### PR TITLE
htmlwidgets support

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,0 +1,28 @@
+build_article <- function(filename) {
+  knitr::opts_knit$set(base.url = "/")
+  knitr::render_markdown()
+  
+  d = gsub('^_|[.][a-zA-Z]+$', '', filename)
+  knitr::opts_chunk$set(
+    fig.path   = sprintf('img/%s/', d),
+    cache.path = sprintf('cache/%s/', d),
+    screenshot.force = FALSE
+  )
+  knitr::opts_knit$set(width = 70)
+  
+  source = paste0('blog_prep/', filename, '.Rmd')
+  dest = paste0('_posts/', filename, '.md')
+  
+  knitr::knit(source, dest, quiet = TRUE, encoding = 'UTF-8', envir = .GlobalEnv)
+  brocks::htmlwidgets_deps(source, always = TRUE)
+  
+  # brocks removes the date... but this blog uses the date on the url... so rename it back :shrug:
+  lose_date <- function(x) {
+    gsub("^[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}-", 
+         "", x)
+  }
+  
+  wrong_name = gsub(".Rmd$", ".html", lose_date(basename(source)))
+  right_name = gsub(".Rmd$", ".html", basename(source))
+  success = file.rename(paste0('_includes/htmlwidgets/', wrong_name), paste0('_includes/htmlwidgets/', right_name))
+}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -97,5 +97,12 @@
   {% elsif site.avatar %}
   <meta name="twitter:image" content="{{ site.url }}{{ site.avatar }}" />
   {% endif %}
+  
+  <!-- add htmlwidget js files -->
+  {% if page.htmlwidget %}
+    {% assign dep_file = page.url | split: '/' | last | prepend : 'htmlwidgets/' | append : '.html' | replace: '.Rmd', '' %}
+    {% include {{dep_file}} %}
+  {% endif %}
+  <!-- end htmlwidget js files -->
 
 </head>


### PR DESCRIPTION
It took a while, but I managed to make this work! it doesn't require you to set up jekyll or anything (although it relies on [brocks](https://github.com/brendan-r/brocks), so make sure you have it installed)

You can see an example of this working [on this page](https://g3rv4-docker.github.io/2017-08-19-datatable/). Feel free to check out [the Rmd file here](https://raw.githubusercontent.com/g3rv4-docker/g3rv4-docker.github.io/master/blog_prep/2017-08-19-datatable.Rmd)

So, things you should do when you have an article that includes an htmlwidget:

1. You need to add `htmlwidget: true` to its front matter
2. In the rstudio console, you need to run `build_article`
3. You need to upload the generated files to github... that's it!

## Adding `htmlwidget: true` to the article's front matter

The front matter of an article is a section delimited by `---` that should go on the top of your articles. In my example, I did

```
---
layout: post
title: "Datatable example"
date: 2017-08-19
htmlwidget: true
---
```

When using this method, make sure it appears only once on the top of your article and that it includes `htmlwidget: true`. That's how you signal Jekyll to include the required javascript files.

## Running `build_article`

You can see I'm adding a `.Rprofile` file. In that script, I have all the magic of the `build_article` :) in the console, you should do:

```
# replacing this with the article you're working on (without the .Rmd extension)
build_article('2017-08-19-datatable')
```

You need to create the `Rmd` files in `blog_prep` as you've been doing.

## Uploading the generated files to github

You'll see this generates a bunch of files... upload all of them (they're the javascript files required to make all the things work)